### PR TITLE
feat: create user assignment task notifications

### DIFF
--- a/backend/src/main/java/com/example/worksync/controller/NotificationController.java
+++ b/backend/src/main/java/com/example/worksync/controller/NotificationController.java
@@ -1,0 +1,39 @@
+package com.example.worksync.controller;
+
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.example.worksync.model.Notification;
+import com.example.worksync.model.User;
+import com.example.worksync.service.NotificationService;
+
+@RestController
+@RequestMapping("/notifications")
+public class NotificationController {
+    @Autowired
+    private NotificationService notificationService;
+
+    @GetMapping
+    public List<Notification> getUnreadNotifications(@AuthenticationPrincipal User user) {
+        return notificationService.getUnreadNotificationsForUser(user);
+    }
+
+    @PostMapping("/{id}/read")
+        public ResponseEntity<Notification> markNotificationAsRead(@PathVariable Long id) {
+        Notification notification = notificationService.markAsRead(id);
+        return ResponseEntity.ok(notification);
+    }
+
+    @PostMapping("/read-all")
+    public List<Notification> markAllNotificationAsRead(@AuthenticationPrincipal User user) {
+        return notificationService.markAllAsRead(user);
+    }
+}

--- a/backend/src/main/java/com/example/worksync/controller/NotificationController.java
+++ b/backend/src/main/java/com/example/worksync/controller/NotificationController.java
@@ -2,7 +2,6 @@ package com.example.worksync.controller;
 
 import java.util.List;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -18,8 +17,12 @@ import com.example.worksync.service.NotificationService;
 @RestController
 @RequestMapping("/notifications")
 public class NotificationController {
-    @Autowired
-    private NotificationService notificationService;
+
+    private final NotificationService notificationService;
+
+    public NotificationController(NotificationService notificationService) {
+        this.notificationService = notificationService;
+    }
 
     @GetMapping
     public List<Notification> getUnreadNotifications(@AuthenticationPrincipal User user) {
@@ -27,7 +30,7 @@ public class NotificationController {
     }
 
     @PostMapping("/{id}/read")
-        public ResponseEntity<Notification> markNotificationAsRead(@PathVariable Long id) {
+    public ResponseEntity<Notification> markNotificationAsRead(@PathVariable Long id) {
         Notification notification = notificationService.markAsRead(id);
         return ResponseEntity.ok(notification);
     }

--- a/backend/src/main/java/com/example/worksync/event/UserTaskAssignmentEvent.java
+++ b/backend/src/main/java/com/example/worksync/event/UserTaskAssignmentEvent.java
@@ -1,0 +1,33 @@
+package com.example.worksync.event;
+
+import org.springframework.context.ApplicationEvent;
+
+import com.example.worksync.model.Task;
+import com.example.worksync.model.User;
+
+public class UserTaskAssignmentEvent extends ApplicationEvent {
+    private User user;
+    private Task task;
+
+    public UserTaskAssignmentEvent(Object source, User user, Task task) {
+        super(source);
+        this.user = user;
+        this.task = task;
+    }
+
+    public User getUser() {
+        return user;
+    }
+
+    public Task getTask() {
+        return task;
+    }
+
+    public void setUser(User user) {
+        this.user = user;
+    }
+
+    public void setTask(Task task) {
+        this.task = task;
+    }
+}

--- a/backend/src/main/java/com/example/worksync/event/UserTaskAssignmentListener.java
+++ b/backend/src/main/java/com/example/worksync/event/UserTaskAssignmentListener.java
@@ -1,6 +1,5 @@
 package com.example.worksync.event;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
 
@@ -10,8 +9,11 @@ import com.example.worksync.service.NotificationService;
 
 @Component
 public class UserTaskAssignmentListener {
-    @Autowired
-    private NotificationService notificationService;
+    private final NotificationService notificationService;
+
+    public UserTaskAssignmentListener(NotificationService notificationService) {
+        this.notificationService = notificationService;
+    }
 
     @EventListener
     public void handleUserTaskAssignment(UserTaskAssignmentEvent event) {

--- a/backend/src/main/java/com/example/worksync/event/UserTaskAssignmentListener.java
+++ b/backend/src/main/java/com/example/worksync/event/UserTaskAssignmentListener.java
@@ -1,0 +1,23 @@
+package com.example.worksync.event;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+import com.example.worksync.model.Task;
+import com.example.worksync.model.User;
+import com.example.worksync.service.NotificationService;
+
+@Component
+public class UserTaskAssignmentListener {
+    @Autowired
+    private NotificationService notificationService;
+
+    @EventListener
+    public void handleUserTaskAssignment(UserTaskAssignmentEvent event) {
+        User user = event.getUser();
+        Task task = event.getTask();
+        String message = "Você foi assinado à tarefa: " + task.getTitle();
+        notificationService.createNotification(user, message, task.getId());
+    }
+}

--- a/backend/src/main/java/com/example/worksync/model/Notification.java
+++ b/backend/src/main/java/com/example/worksync/model/Notification.java
@@ -1,0 +1,88 @@
+package com.example.worksync.model;
+
+import java.time.LocalDateTime;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+
+@Entity
+public class Notification {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    private User user;
+
+    private String message;
+    private boolean read;
+
+    private Long taskId;
+
+    private LocalDateTime createdAt;
+
+    public Notification () {}
+
+    public Notification(User user, String message, boolean read, Long taskId) {
+        this.user = user;
+        this.message = message;
+        this.read = read;
+        this.taskId = taskId;
+        this.createdAt = LocalDateTime.now();
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public User getUser() {
+        return user;
+    }
+
+    public void setUser(User user) {
+        this.user = user;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public void setMessage(String message) {
+        this.message = message;
+    }
+
+    public boolean isRead() {
+        return read;
+    }
+
+    public void setRead(boolean read) {
+        this.read = read;
+    }
+
+    public void markAsRead() {
+        this.read = true;
+    }
+
+    public Long getTaskId() {
+        return taskId;
+    }
+
+    public void setTaskId(Long taskId) {
+        this.taskId = taskId;
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(LocalDateTime createdAt) {
+        this.createdAt = createdAt;
+    }
+}

--- a/backend/src/main/java/com/example/worksync/model/Task.java
+++ b/backend/src/main/java/com/example/worksync/model/Task.java
@@ -1,5 +1,6 @@
 package com.example.worksync.model;
 
+import java.io.Serializable;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.ArrayList;
@@ -20,7 +21,7 @@ import jakarta.persistence.Table;
 
 @Entity
 @Table(name = "tasks")
-public class Task {
+public class Task implements Serializable {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/backend/src/main/java/com/example/worksync/repository/NotificationRepostiory.java
+++ b/backend/src/main/java/com/example/worksync/repository/NotificationRepostiory.java
@@ -1,0 +1,16 @@
+package com.example.worksync.repository;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.example.worksync.model.Notification;
+import com.example.worksync.model.User;
+
+@Repository
+public interface NotificationRepostiory extends JpaRepository<Notification, Long> {
+    List<Notification> findByUserAndReadFalse(User user);
+
+    long countByUserAndReadFalse(User user);
+}

--- a/backend/src/main/java/com/example/worksync/service/NotificationService.java
+++ b/backend/src/main/java/com/example/worksync/service/NotificationService.java
@@ -2,7 +2,6 @@ package com.example.worksync.service;
 
 import java.util.List;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import com.example.worksync.exceptions.NotFoundException;
@@ -12,8 +11,12 @@ import com.example.worksync.repository.NotificationRepostiory;
 
 @Service
 public class NotificationService {
-    @Autowired
-    private NotificationRepostiory notificationRepository;
+
+    private final NotificationRepostiory notificationRepository;
+
+    public NotificationService(NotificationRepostiory notificationRepository) {
+        this.notificationRepository = notificationRepository;
+    }
 
     public void createNotification(User user, String message, Long taskId) {
         Notification notification = new Notification(user, message, false, taskId);
@@ -27,7 +30,7 @@ public class NotificationService {
     public Notification markAsRead(Long notificationId) {
         Notification notification = notificationRepository.findById(notificationId)
                 .orElseThrow(() -> new NotFoundException("Notification not found"));
-        
+
         notification.markAsRead();
         notificationRepository.save(notification);
         return notification;

--- a/backend/src/main/java/com/example/worksync/service/NotificationService.java
+++ b/backend/src/main/java/com/example/worksync/service/NotificationService.java
@@ -1,0 +1,45 @@
+package com.example.worksync.service;
+
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import com.example.worksync.exceptions.NotFoundException;
+import com.example.worksync.model.Notification;
+import com.example.worksync.model.User;
+import com.example.worksync.repository.NotificationRepostiory;
+
+@Service
+public class NotificationService {
+    @Autowired
+    private NotificationRepostiory notificationRepository;
+
+    public void createNotification(User user, String message, Long taskId) {
+        Notification notification = new Notification(user, message, false, taskId);
+        notificationRepository.save(notification);
+    }
+
+    public List<Notification> getUnreadNotificationsForUser(User user) {
+        return notificationRepository.findByUserAndReadFalse(user);
+    }
+
+    public Notification markAsRead(Long notificationId) {
+        Notification notification = notificationRepository.findById(notificationId)
+                .orElseThrow(() -> new NotFoundException("Notification not found"));
+        
+        notification.markAsRead();
+        notificationRepository.save(notification);
+        return notification;
+    }
+
+    public List<Notification> markAllAsRead(User user) {
+        List<Notification> unreadNotifications = notificationRepository.findByUserAndReadFalse(user);
+        for (Notification notification : unreadNotifications) {
+            notification.markAsRead();
+        }
+        notificationRepository.saveAll(unreadNotifications);
+        return unreadNotifications;
+    }
+
+}


### PR DESCRIPTION
- Adicionando evento de notificação quando o usuário é assinado a uma tarefa.

```python
GET
/notifications # Buscar notificações do usuário logado.

POST 
/notifications/:id/read # Atualiza o campo READ para true, para sinalizar que a notificação foi aberta.

POST 
/notifications/read-all # Atualiza o campo READ para true de todas as notificações do usuário logado.
```

https://hopp.sh/r/eRoXETIW4nJd

![image](https://github.com/user-attachments/assets/67ca23be-253a-4423-a56d-25a0a2b885b0)


